### PR TITLE
feat: add ai suggestion service, connect it to ticket controller

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -18,6 +18,8 @@ const requiredVars = [
   "FRONTEND_URL",
   "PORT",
   "OPENAI_API_KEY",
+  "AI_EMBEDDING_MODEL",
+  "AI_SUGGESTIONS_MODEL",
   "NODE_ENV",
 ] as const;
 
@@ -43,4 +45,6 @@ export const JWT_REFRESH_SECRET_EXPIRATION = env.JWT_REFRESH_SECRET_EXPIRATION; 
 export const FRONTEND_URL = env.FRONTEND_URL; //Origin URL for CORS
 export const PORT = env.PORT; // Port on which the backend server will run
 export const OPENAI_API_KEY = env.OPENAI_API_KEY; // OpenAI API key
+export const AI_EMBEDDING_MODEL = env.AI_EMBEDDING_MODEL; // Model for getting embeddings
+export const AI_SUGGESTIONS_MODEL = env.AI_SUGGESTIONS_MODEL; // Model for getting ticket suggestions
 export const NODE_ENV = env.NODE_ENV; // Environment mode (development, production)

--- a/backend/src/services/openai.service.ts
+++ b/backend/src/services/openai.service.ts
@@ -4,17 +4,17 @@
  */
 
 import OpenAI from "openai";
-import { OPENAI_API_KEY } from "../config/env.js";
+import {
+  OPENAI_API_KEY,
+  AI_EMBEDDING_MODEL,
+  AI_SUGGESTIONS_MODEL,
+} from "../config/env.js";
 import { InternalServerError } from "../utils/errors.js";
 
-// 1. Initialize the OpenAI client with the API key from our environment variables.
+// Initialize the OpenAI client with the API key from our environment variables.
 const openai = new OpenAI({
   apiKey: OPENAI_API_KEY,
 });
-
-// 2. Define the model to use. 'text-embedding-3-small' is efficient and produces
-//    vectors of size 1536.
-const EMBEDDING_MODEL = "text-embedding-3-small";
 
 /**
  * @description Generates a vector embedding for a given text string.
@@ -23,14 +23,14 @@ const EMBEDDING_MODEL = "text-embedding-3-small";
  */
 export const getEmbedding = async (text: string): Promise<number[]> => {
   try {
-    // 3. Make the API call to the embeddings endpoint.
+    // Make the API call to the embeddings endpoint.
     const response = await openai.embeddings.create({
-      model: EMBEDDING_MODEL,
+      model: AI_EMBEDDING_MODEL, // Embedding model should produce vectors of size 1536. 'text-embedding-ada-002'
       input: text.replace(/\n/g, " "), // replacing newlines with spaces.
       dimensions: 1536, // Explicitly request 1536 dimensions to match pgvector.
     });
 
-    // 4. Validate the response and extract the embedding.
+    // Validate the response and extract the embedding.
     const embedding = response?.data?.[0]?.embedding;
     if (!embedding) {
       throw new Error("Invalid response structure from OpenAI API.");
@@ -39,7 +39,45 @@ export const getEmbedding = async (text: string): Promise<number[]> => {
     return embedding;
   } catch (error) {
     console.error("Error fetching embedding from OpenAI:", error);
-    // 5. Throw a standardized server error to be caught by your global error handler.
+    // Throw a standardized server error to be caught by your global error handler.
     throw new InternalServerError("Failed to generate text embedding.");
+  }
+};
+
+/**
+ * @description Gets a text response from the OpenAI chat model.
+ * @param prompt - The detailed prompt for the AI.
+ * @returns A promise that resolves to the AI's response string.
+ */
+export const getChatCompletion = async (
+  prompt: string
+): Promise<string | null> => {
+  try {
+    const response = await openai.chat.completions.create({
+      model: AI_SUGGESTIONS_MODEL, // 'gpt-4o-mini
+      messages: [
+        {
+          role: "system",
+          content: "You are a helpful AI assistant.", // General system message
+        },
+        {
+          role: "user",
+          content: prompt, // The detailed prompt generated in ai.service levele
+        },
+      ],
+      temperature: 0.5, // A bit of creativity but still factual
+      max_tokens: 500,
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) {
+      throw new Error(
+        "Invalid response structure from OpenAI API for chat completion."
+      );
+    }
+    return content;
+  } catch (error) {
+    console.error("Error fetching chat completion from OpenAI:", error);
+    throw new InternalServerError("Failed to generate AI suggestion.");
   }
 };


### PR DESCRIPTION
1. Add the ai.service layer for preparing a prompt and getting AI suggestions: semantic search in the articles table, build a prompt with a pre-configured template.
2. Save a ticket description to the ticket table (early only in the ticketMessage table). It makes access to the data easier and convenient.
3. Add to the open.ai service function for getting a suggestion from GPT-4o-mini.
4. Move models definition to env.  