### PR TITLE
fix: infinite loop with resrefToken and password update

### DIFF
--- a/frontend/src/api/setupInterceptors.ts
+++ b/frontend/src/api/setupInterceptors.ts
@@ -12,7 +12,7 @@ import api from "../lib/axios";
 const setupAxiosInterceptors = (store: Store) => {
   /**
    * Request Interceptor: This function runs before every single request is sent.
-   * Its job is to grab the latest accessToken from your Redux state and add it to
+   * Its job is to grab the latest accessToken from Redux state and add it to
    * the Authorization header.
    */
   api.interceptors.request.use(
@@ -41,7 +41,11 @@ const setupAxiosInterceptors = (store: Store) => {
       const originalRequest = error.config;
 
       // Check if the error is 401 and we haven't already retried this request
-      if (error.response.status === 401 && !originalRequest._retry) {
+      if (
+        error.response.status === 401 &&
+        !originalRequest._retry &&
+        originalRequest.url !== "/auth/refresh"
+      ) {
         originalRequest._retry = true; // Mark the request to prevent infinite loops
 
         try {


### PR DESCRIPTION
Fix bug with infinite loop when user tries to log in with wrong credentials
Fix password update by PUT /users/:id route 