### PR TITLE
fix: simultaneous occurrence of two KB modal windows

### DIFF
--- a/frontend/src/features/knowledgeBase/components/ArticleList.tsx
+++ b/frontend/src/features/knowledgeBase/components/ArticleList.tsx
@@ -57,7 +57,7 @@ export const ArticleList: FunctionComponent<ArticleListProps> = ({
               <TableCell>{article.tags?.join(", ")}</TableCell>
               {/* Conditionally render the action buttons */}
               {canManage && (
-                <TableCell align="right">
+                <TableCell align="right" onClick={(e) => e.stopPropagation()}>
                   <Tooltip title="Edit">
                     <IconButton onClick={() => onEdit(article)}>
                       <EditIcon />


### PR DESCRIPTION
Fix: Prevent Simultaneous Modal Windows
This pull request resolves an issue where two knowledge base modal windows could occasionally appear at the same time, leading to a broken user experience.