### PR TITLE
Fix: add user-friendly message for invalid login

### DIFF
--- a/frontend/src/features/auth/authSlice.ts
+++ b/frontend/src/features/auth/authSlice.ts
@@ -57,7 +57,9 @@ export const loginUser = createAsyncThunk<
     );
     return { accessToken: data.accessToken };
   } catch (err: any) {
-    return rejectWithValue(err.message || "Failed to login");
+    const errorMessage =
+      err.response?.data?.message || "An unexpected error occurred.";
+    return rejectWithValue(errorMessage);
   }
 });
 
@@ -67,8 +69,8 @@ export const logoutUser = createAsyncThunk(
     try {
       await api.post("/auth/logout");
     } catch (err: any) {
-      const errorMsg = err.response?.data?.message || "Failed to logout";
-      return rejectWithValue(errorMsg);
+      const errorMessage = err.response?.data?.message || "Failed to logout";
+      return rejectWithValue(errorMessage);
     }
   }
 );


### PR DESCRIPTION
Fix: User-Friendly Login Error Messages
This pull request introduces more user-friendly and specific error messages for failed login attempts. Previously, the error message was AXIOS generic and did not provide helpful feedback to the user.

Details
Problem: When a user attempted to log in with incorrect credentials, they would receive a vague error message like "Request failed with status code 401". This did not help them understand the cause of the problem.

Solution: The authentication async thunk has been updated to capture the specific error message from the server's response. The code now checks for a message within the err.response?.data?.message property and uses it directly.