### PR TITLE
feat: add user service and route for changing password

### DIFF
--- a/backend/src/controllers/category.controller.ts
+++ b/backend/src/controllers/category.controller.ts
@@ -11,6 +11,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../utils/errors.js";
+import { getRouteParam } from "../utils/routeParams.js";
 import type {
   NewCategory,
   CategoryUpdateData,
@@ -58,13 +59,9 @@ export const categoryController = {
    * @route PUT api/categories/:id
    */
   async updateCategory(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Category ID");
     const { name } = req.body;
     const currentUser = req.user as JwtPayload;
-
-    if (!id) {
-      throw new BadRequestError("Category ID is required.");
-    }
 
     const category = await categoryModel.findById(id);
     if (!category) {
@@ -89,12 +86,8 @@ export const categoryController = {
    * @route DELETE api/categories/:id
    */
   async deleteCategory(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Category ID");
     const currentUser = req.user as JwtPayload;
-
-    if (!id) {
-      throw new BadRequestError("Category ID is required.");
-    }
 
     const category = await categoryModel.findById(id);
     if (!category) {

--- a/backend/src/controllers/client.controller.ts
+++ b/backend/src/controllers/client.controller.ts
@@ -6,6 +6,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../utils/errors.js";
+import { getRouteParam } from "../utils/routeParams.js";
 
 export const clientController = {
   /**
@@ -59,11 +60,8 @@ export const clientController = {
    * @route PUT /api/clients/:id
    */
   async updateClient(req: Request, res: Response): Promise<Response> {
-    const clientId = req.params.id;
+    const clientId = getRouteParam(req.params.id, "Client ID");
     const { name, settings } = req.body;
-    if (!clientId) {
-      throw new BadRequestError("Client ID is required.");
-    }
 
     const updatedData: Partial<Omit<NewClient, "client_id">> = {}; // Exclude client_id from update
 
@@ -83,10 +81,7 @@ export const clientController = {
    * @route DELETE /api/clients/:id
    */
   async deleteClient(req: Request, res: Response): Promise<Response> {
-    const clientId = req.params.id;
-    if (!clientId) {
-      throw new BadRequestError("Client ID is required.");
-    }
+    const clientId = getRouteParam(req.params.id, "Client ID");
     const deletedCount = await clientModel.remove(clientId);
     if (deletedCount === 0) {
       throw new NotFoundError("Client not found.");

--- a/backend/src/controllers/equipment.controller.ts
+++ b/backend/src/controllers/equipment.controller.ts
@@ -11,6 +11,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../utils/errors.js";
+import { getRouteParam } from "../utils/routeParams.js";
 import { ROLES } from "../types/index.js";
 import type {
   NewEquipment,
@@ -65,12 +66,8 @@ export const equipmentController = {
    * @description Gets a single piece of equipment by its ID.
    */
   async getEquipmentById(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Equipment ID");
     const currentUser = req.user as JwtPayload;
-
-    if (!id) {
-      throw new BadRequestError("Equipment ID is required.");
-    }
 
     const equipment = await equipmentModel.findById(id);
     if (!equipment) {
@@ -94,12 +91,8 @@ export const equipmentController = {
    * @description Updates a piece of equipment.
    */
   async updateEquipment(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Equipment ID");
     const currentUser = req.user as JwtPayload;
-
-    if (!id) {
-      throw new BadRequestError("Equipment ID is required.");
-    }
 
     const equipment = await equipmentModel.findById(id);
     if (!equipment) {
@@ -129,12 +122,8 @@ export const equipmentController = {
    * @description Deletes a piece of equipment.
    */
   async deleteEquipment(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Equipment ID");
     const currentUser = req.user as JwtPayload;
-
-    if (!id) {
-      throw new BadRequestError("Equipment ID is required.");
-    }
 
     const equipment = await equipmentModel.findById(id);
     if (!equipment) {

--- a/backend/src/controllers/knowledge.controller.ts
+++ b/backend/src/controllers/knowledge.controller.ts
@@ -12,6 +12,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../utils/errors.js";
+import { getRouteParam } from "../utils/routeParams.js";
 import {
   type NewKnowledgeArticle,
   type KnowledgeArticleUpdateData,
@@ -71,12 +72,8 @@ export const knowledgeController = {
    * @description Gets a single article by ID.
    */
   async getArticleById(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Article ID");
     const currentUser = req.user as JwtPayload;
-    // Validate input
-    if (!id) {
-      throw new BadRequestError("Article ID is required.");
-    }
 
     const article = await knowledgeArticleModel.findById(id);
     if (!article) {
@@ -100,14 +97,10 @@ export const knowledgeController = {
    * @description Updates an existing knowledge article.
    */
   async updateArticle(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Article ID");
     const { title, content, tags } = req.body;
     const currentUser = req.user as JwtPayload;
 
-    // Validate input
-    if (!id) {
-      throw new BadRequestError("Article ID is required.");
-    }
     if (!title && !content && !tags) {
       throw new BadRequestError(
         "At least one field (title, content, tags) is required."
@@ -149,12 +142,8 @@ export const knowledgeController = {
    * @description Deletes a knowledge article.
    */
   async deleteArticle(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "Article ID");
     const currentUser = req.user as JwtPayload;
-    // Validate input
-    if (!id) {
-      throw new BadRequestError("Article ID is required.");
-    }
 
     const article = await knowledgeArticleModel.findById(id);
     if (!article) {

--- a/backend/src/controllers/ticket.controller.ts
+++ b/backend/src/controllers/ticket.controller.ts
@@ -15,6 +15,7 @@ import {
   ForbiddenError,
   NotFoundError,
 } from "../utils/errors.js";
+import { getRouteParam } from "../utils/routeParams.js";
 
 import { ROLES, STATUSES } from "../types/index.js";
 import type {
@@ -119,12 +120,9 @@ export const ticketController = {
    * @route GET /tickets/:ticketId
    */
   async getTicketById(req: Request, res: Response): Promise<Response> {
-    const { ticketId } = req.params;
+    const ticketId = getRouteParam(req.params.ticketId, "Ticket ID");
     const currentUser = req.user as JwtPayload;
 
-    if (!ticketId) {
-      throw new BadRequestError("Ticket ID is required.");
-    }
     const ticket = await ticketModel.findById(ticketId);
     if (!ticket) {
       throw new NotFoundError("Ticket not found.");
@@ -149,13 +147,9 @@ export const ticketController = {
    * @route PUT /tickets/:ticketId
    */
   async updateTicket(req: Request, res: Response): Promise<Response> {
-    const { ticketId } = req.params;
+    const ticketId = getRouteParam(req.params.ticketId, "Ticket ID");
     const { status, priority, equipment_id } = req.body;
     const currentUser = req.user as JwtPayload;
-
-    if (!ticketId) {
-      throw new BadRequestError("Ticket ID is required.");
-    }
 
     const ticket = await ticketModel.findById(ticketId);
     if (!ticket) {
@@ -197,13 +191,9 @@ export const ticketController = {
    * @route POST /tickets/:ticketId/messages
    */
   async addMessage(req: Request, res: Response): Promise<Response> {
-    const { ticketId } = req.params;
+    const ticketId = getRouteParam(req.params.ticketId, "Ticket ID");
     const { content } = req.body;
     const currentUser = req.user as JwtPayload;
-
-    if (!ticketId) {
-      throw new BadRequestError("Ticket ID is required.");
-    }
 
     if (!content) {
       throw new BadRequestError("Message content is required.");
@@ -244,14 +234,10 @@ export const ticketController = {
    * @route POST /tickets/:ticketId/feedback
    */
   async addFeedback(req: Request, res: Response): Promise<Response> {
-    const { ticketId } = req.params;
+    const ticketId = getRouteParam(req.params.ticketId, "Ticket ID");
     const { ai_response_id, rating, comment } = req.body;
     const currentUser = req.user as JwtPayload;
 
-    // Validate input
-    if (!ticketId) {
-      throw new BadRequestError("Ticket ID is required.");
-    }
     if (!ai_response_id || !rating) {
       throw new BadRequestError("ai_response_id and rating are required.");
     }

--- a/backend/src/controllers/user.controller.ts
+++ b/backend/src/controllers/user.controller.ts
@@ -2,7 +2,9 @@ import type { Request, Response } from "express";
 import { userModel } from "../model/userModel.js";
 import bcrypt from "bcrypt";
 import type { UserDB, NewUser, JwtPayload } from "../types/index.js";
+import { userService } from "../services/user.service.js";
 import { sanitizeUser } from "../utils/sanitize.js";
+import { getRouteParam } from "../utils/routeParams.js";
 import {
   BadRequestError,
   NotFoundError,
@@ -146,10 +148,7 @@ export const userController = {
    * @route GET /api/users/:id
    */
   async getUserById(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
-    if (!id) {
-      throw new BadRequestError("User ID is required.");
-    }
+    const id = getRouteParam(req.params.id, "User ID");
     const targetUser = await userModel.findById(id);
 
     if (!targetUser) {
@@ -170,13 +169,10 @@ export const userController = {
    * @route PUT /api/users/:id
    */
   async updateUser(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "User ID");
     const { email, role, name, password } = req.body;
     const currentUser = req.user as JwtPayload;
 
-    if (!id) {
-      throw new BadRequestError("User ID is required.");
-    }
     const targetUser = await userModel.findById(id);
     if (!targetUser) {
       throw new NotFoundError("User not found.");
@@ -224,11 +220,8 @@ export const userController = {
    * @route DELETE /api/users/:id
    */
   async deleteUser(req: Request, res: Response): Promise<Response> {
-    const { id } = req.params;
+    const id = getRouteParam(req.params.id, "User ID");
     const currentUser = req.user as JwtPayload;
-    if (!id) {
-      throw new BadRequestError("User ID is required.");
-    }
     const targetUser = await userModel.findById(id);
     if (!targetUser) {
       // We still return 204 for idempotency, but we check first for auth.
@@ -264,27 +257,23 @@ export const userController = {
    * @route PUT /api/users/me/password
    */
   async updateMyPassword(req: Request, res: Response): Promise<Response> {
-    const userId = req.user?.userId;
+    const jwtUser = req.user as JwtPayload | undefined;
     const { currentPassword, newPassword } = req.body;
 
-    if (!userId) {
+    if (!jwtUser?.userId) {
       throw new UnauthorizedError("Unauthorized: No user information found.");
     }
 
-    const user = await userModel.findById(userId);
-    if (!user) {
-      throw new NotFoundError("User not found");
-    }
-
-    // Verify current password
-    const isMatch = await bcrypt.compare(currentPassword, user.password_hash);
-    if (!isMatch) {
-      throw new BadRequestError("Current password is incorrect.");
-    }
-
-    // Update password
-    user.password_hash = await bcrypt.hash(newPassword, SALT_ROUNDS);
-    await userModel.update(userId, { password_hash: user.password_hash });
+    await userService.updateUserPassword(
+      {
+        id: jwtUser.userId,
+        role: jwtUser.role,
+        client_id: jwtUser.clientId,
+      },
+      jwtUser.userId,
+      currentPassword,
+      newPassword
+    );
 
     return res.status(200).json({ message: "Password updated successfully." });
   }

--- a/backend/src/model/userModel.ts
+++ b/backend/src/model/userModel.ts
@@ -1,6 +1,6 @@
 // models/userModel.ts
 import db from "../db/db.js";
-import type { UserDB, NewUser } from "../types/index.js";
+import type { UserDB, NewUser, UserSanitized } from "../types/index.js";
 import type { Knex } from "knex";
 
 const TABLE_NAME = "users";
@@ -40,15 +40,7 @@ export const userModel = {
       const [user] = await db<UserDB>(TABLE_NAME)
         .where({ id })
         .update(userData) // Update only the fields provided
-        .returning([
-          "id",
-          "client_id",
-          "email",
-          "password_hash",
-          "role",
-          "name",
-          "created_at",
-        ]);
+        .returning(["id", "client_id", "email", "role", "name", "created_at"]);
       if (!user) {
         throw new Error("User not found");
       }
@@ -57,6 +49,27 @@ export const userModel = {
       console.error("Error updating user:", error);
       throw new Error("Failed to update user");
     }
+  },
+
+  /**
+   * Updates the password for a user.
+   * @param id - The user's UUID.
+   * @param new_password_hash - The new password hash.
+   */
+  async updatePassword(
+    id: string,
+    new_password_hash: string
+  ): Promise<UserSanitized> {
+    const [user] = await db<UserDB>(TABLE_NAME)
+      .where({ id })
+      .update({ password_hash: new_password_hash })
+      .returning(["id", "client_id", "email", "role", "name", "created_at"]);
+
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    return user as UserSanitized;
   },
 
   /**

--- a/backend/src/model/userModel.ts
+++ b/backend/src/model/userModel.ts
@@ -1,6 +1,7 @@
 // models/userModel.ts
 import db from "../db/db.js";
 import type { UserDB, NewUser, UserSanitized } from "../types/index.js";
+import { NotFoundError } from "../utils/errors.js";
 import type { Knex } from "knex";
 
 const TABLE_NAME = "users";
@@ -66,7 +67,7 @@ export const userModel = {
       .returning(["id", "client_id", "email", "role", "name", "created_at"]);
 
     if (!user) {
-      throw new Error("User not found");
+      throw new NotFoundError("User not found");
     }
 
     return user as UserSanitized;

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -19,6 +19,7 @@ router.use(authMiddleware, checkPermission(resource));
 router.get("/", catchAsync(userController.getAllUsers));
 router.post("/", catchAsync(userController.createUser));
 router.get("/me", catchAsync(userController.getMeProfile));
+router.put("/me/password", catchAsync(userController.updateMyPassword));
 router.get("/:id", catchAsync(userController.getUserById));
 router.put("/:id", catchAsync(userController.updateUser));
 router.delete("/:id", catchAsync(userController.deleteUser));

--- a/backend/src/routes/users.routes.ts
+++ b/backend/src/routes/users.routes.ts
@@ -12,14 +12,20 @@ import { checkPermission } from "../middlewares/rbac.middleware.js";
 const router = Router();
 const resource = "users";
 
+// Self-service routes: any authenticated user (auth only, no RBAC PUT on users).
+router.get("/me", authMiddleware, catchAsync(userController.getMeProfile));
+router.put(
+  "/me/password",
+  authMiddleware,
+  catchAsync(userController.updateMyPassword)
+);
+
 // Protected routes with role-based access control
 // This middleware checks if the user is authenticated and has the right permissions for the 'users'
 router.use(authMiddleware, checkPermission(resource));
 
 router.get("/", catchAsync(userController.getAllUsers));
 router.post("/", catchAsync(userController.createUser));
-router.get("/me", catchAsync(userController.getMeProfile));
-router.put("/me/password", catchAsync(userController.updateMyPassword));
 router.get("/:id", catchAsync(userController.getUserById));
 router.put("/:id", catchAsync(userController.updateUser));
 router.delete("/:id", catchAsync(userController.deleteUser));

--- a/backend/src/services/user.service.ts
+++ b/backend/src/services/user.service.ts
@@ -1,10 +1,5 @@
 import bcrypt from "bcrypt";
-import type {
-  NewUser,
-  UserDB,
-  NewUserInput,
-  UserSanitized,
-} from "../types/index.js";
+import type { NewUser, UserDB, NewUserInput, Role } from "../types/index.js";
 import { userModel } from "../model/userModel.js";
 import { ROLES } from "../types/index.js";
 import {
@@ -17,6 +12,12 @@ import type { Knex } from "knex";
 
 // The number of salt rounds for hashing the password.
 const SALT_ROUNDS = 10;
+
+export type PasswordChangeActor = {
+  id: string;
+  role: Role;
+  client_id: string;
+};
 
 type CreateUserOpts = {
   newUserData: NewUserInput;
@@ -68,23 +69,33 @@ export const userService = {
     // --- 3. Hash password ---
     const password_hash = await bcrypt.hash(newUserData.password, SALT_ROUNDS);
 
+    const { password, client_id, ...userFields } = newUserData;
+    if (!client_id) {
+      throw new BadRequestError("client_id is required.");
+    }
+
     // 4. Create the user in the database
     const newUserPayload: NewUser = {
-      ...newUserData,
+      ...userFields,
+      client_id,
       password_hash,
     };
-    delete (newUserPayload as any).password;
 
     const createdUser = await userModel.create(newUserPayload, trx);
     return createdUser;
   },
 
   async updateUserPassword(
-    currentUser: UserSanitized,
+    currentUser: PasswordChangeActor,
     userId: string,
     currentPassword: string,
     newPassword: string
   ): Promise<void> {
+    if (!currentPassword || !newPassword) {
+      throw new BadRequestError(
+        "currentPassword and newPassword are required."
+      );
+    }
     // Find the user for password update
     const user = await userModel.findById(userId);
     if (!user) {

--- a/backend/src/types/db/user.ts
+++ b/backend/src/types/db/user.ts
@@ -15,6 +15,11 @@ export interface UserDB {
 }
 
 /**
+ * Represents a user without the password hash.
+ */
+export type UserSanitized = Omit<UserDB, "password_hash">;
+
+/**
  * Type for creating a new user, based on the full DB entity.
  * Ready to insert in DB type.
  */
@@ -24,10 +29,8 @@ export type NewUser = Omit<UserDB, "id" | "created_at">;
  * Type for creating a new user input, excluding hashed password which will be generated.
  * The client_id is optional to allow for initial user creation without a client.
  */
-export type NewUserInput = Optional<
-  Omit<UserDB, "id" | "created_at" | "password_hash">,
-  "client_id"
-> & {
+export type NewUserInput =
+  Omit<UserDB, "id" | "created_at" | "password_hash"> & {
   password: string;
 };
 

--- a/backend/src/types/db/user.ts
+++ b/backend/src/types/db/user.ts
@@ -29,8 +29,10 @@ export type NewUser = Omit<UserDB, "id" | "created_at">;
  * Type for creating a new user input, excluding hashed password which will be generated.
  * The client_id is optional to allow for initial user creation without a client.
  */
-export type NewUserInput =
-  Omit<UserDB, "id" | "created_at" | "password_hash"> & {
+export type NewUserInput = Optional<
+  Omit<UserDB, "id" | "created_at" | "password_hash">,
+  "client_id"
+> & {
   password: string;
 };
 

--- a/backend/src/utils/routeParams.ts
+++ b/backend/src/utils/routeParams.ts
@@ -1,0 +1,18 @@
+import { BadRequestError } from "./errors.js";
+
+/**
+ * Normalizes an Express route param to a single string.
+ * Express 5 types params as `string | string[]`.
+ */
+export const getRouteParam = (
+  value: string | string[] | undefined,
+  paramName: string
+): string => {
+  if (Array.isArray(value)) {
+    throw new BadRequestError(`${paramName} must be a single value.`);
+  }
+  if (!value) {
+    throw new BadRequestError(`${paramName} is required.`);
+  }
+  return value;
+};

--- a/backend/src/utils/sanitize.ts
+++ b/backend/src/utils/sanitize.ts
@@ -1,11 +1,11 @@
-import type { UserDB } from "../types/index.js";
+import type { UserDB, UserSanitized } from "../types/index.js";
 
 /**
  * @description Helper function to remove sensitive data from the user object before sending it to the client.
  * @param user - The user object from the database.
  * @returns The user object without the password hash.
  */
-export const sanitizeUser = (user: UserDB): Omit<UserDB, "password_hash"> => {
+export const sanitizeUser = (user: UserDB): UserSanitized => {
   const { password_hash, ...sanitizedUser } = user;
   return sanitizedUser;
 };


### PR DESCRIPTION
# ✨ Summary
- Add endpoint to let authenticated users update their own password.
- Add service and model helpers to validate and persist password changes safely.
- Wire routing and types to support sanitized user updates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches password-handling and authorization logic and introduces a new password-change endpoint, so mistakes could impact account security; changes are localized but security-sensitive.
> 
> **Overview**
> Adds a new protected endpoint, `PUT /api/users/me/password`, that verifies the caller’s `currentPassword`, hashes `newPassword`, and persists the updated `password_hash`.
> 
> Refactors `userModel.update` to no longer return `password_hash`, introduces `userModel.updatePassword`, and adds a `UserSanitized` type; also adds a `userService.updateUserPassword` helper with role-based rules for self/admin/client-admin password changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a961984b12999419d0ad138a050c3b32b470c815. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->